### PR TITLE
bucket name enforced to be lowercase

### DIFF
--- a/blocks/name.js
+++ b/blocks/name.js
@@ -15,7 +15,7 @@ module.exports.resolve = ({serverless, variableUtils, slsHelper, logUtils}) => {
 
   const getBucketName = async (awsAccountDomainName) => {
     const product = await resolveVariable('self:custom.product');
-    return `${product}.${slsHelper.region}.${awsAccountDomainName}`;
+    return `${product}.${slsHelper.region}.${awsAccountDomainName}`.toLocaleLowerCase();
   };
 
   const isBucketCreationNecessary = (bucketName) => {


### PR DESCRIPTION
The lower case method is applied when the bucket name is resolved and assigned to the const variable.

Issue with discussion: https://github.com/walery/stencil-aws-account-resolver/issues/1